### PR TITLE
Merge `What's been done` and `TODO`

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,10 +5,8 @@ A brief description of the underlying problem.
 E.g.: the root cause of the bug that this PR aims to fix
 
 ### What's been done
-A brief description of the solution, in terms of code changes.
-
-### To do
-- [ ] Checklist of remaining tasks before this PR can be considered "complete"
+- [ ] A brief description of the solution, in terms of code changes
+- [ ] A brief description of the remaining tasks before this PR can be considered "complete"
 
 ### Test
 Test scenarios + relative evidence.


### PR DESCRIPTION
No JIRA ticket

### The problem
There's a bit of overlapping between `What's been done` and `TODO`: `TODO` contains a (very cool) checklist; as soon as an element in the `TODO` checklist gets ticked, it can be considered part of `What's been done`.

### What's been done
- [x] Think if it makes sense to merge `What's been done` and `TODO`
- [x] Propose the idea to the rest of the team
- [x] Consider three :+1: an enthusiastic "yes!"
- [x] Create this PR
- [ ] Wait for the approval of this PR
- [ ] Get it merged

### Test
This comment
